### PR TITLE
Add logic for r=-1 in Dynamic case, Add tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export const parse = (manifestString, options) =>
 /**
  * Parses the manifest for a UTCTiming node, returning the nodes attributes if found
  *
- * @param {String} manifestString
+ * @param {string} manifestString
  *        XML string of the MPD manifest
  * @return {Object|null}
  *         Attributes of UTCTiming node specified in the manifest. Null if none found

--- a/src/inheritAttributes.js
+++ b/src/inheritAttributes.js
@@ -173,6 +173,8 @@ export const inheritBaseUrls =
  *        Contains attributes inherited by the Period
  * @param {string[]} periodBaseUrls
  *        Contains list of resolved base urls inherited by the Period
+ * @param {string[]} periodSegmentInfo
+ *        Contains Segment Information at the period level
  * @return {toRepresentationsCallback}
  *         Callback map function
  */
@@ -236,8 +238,14 @@ export const toAdaptationSets = (mpdAttributes, mpdBaseUrls) => (period, periodI
  *
  * @param {Node} mpd
  *        The root node of the mpd
- * @param {string} manifestUri
- *        The uri of the source mpd
+ * @param {Object} options
+ *        Available options for inheritAttributes
+ * @param {string} options.manifestUri
+ *        The uri source of the mpd
+ * @param {number} options.NOW
+ *        Current time per DASH IOP.  Default is current time in ms since epoch
+ * @param {number} options.clientOffset
+ *        Client time difference from NOW (in milliseconds)
  * @return {RepresentationInformation[]}
  *         List of objects containing Representation information
  */

--- a/src/parseAttributes.js
+++ b/src/parseAttributes.js
@@ -7,9 +7,9 @@ export const parsers = {
    * Specifies the duration of the entire Media Presentation. Format is a duration string
    * as specified in ISO 8601
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The duration in seconds
    */
   mediaPresentationDuration(value) {
@@ -21,9 +21,9 @@ export const parsers = {
    * MPD. For a dynamic manifest, it specifies the anchor for the earliest availability
    * time. Format is a date string as specified in ISO 8601
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The date as seconds from unix epoch
    */
   availabilityStartTime(value) {
@@ -34,9 +34,9 @@ export const parsers = {
    * Specifies the smallest period between potential changes to the MPD. Format is a
    * duration string as specified in ISO 8601
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The duration in seconds
    */
   minimumUpdatePeriod(value) {
@@ -47,9 +47,9 @@ export const parsers = {
    * Specifies the duration of the smallest time shifting buffer for any Representation
    * in the MPD. Format is a duration string as specified in ISO 8601
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The duration in seconds
    */
   timeShiftBufferDepth(value) {
@@ -60,9 +60,9 @@ export const parsers = {
    * Specifies the PeriodStart time of the Period relative to the availabilityStarttime.
    * Format is a duration string as specified in ISO 8601
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The duration in seconds
    */
   start(value) {
@@ -72,9 +72,9 @@ export const parsers = {
   /**
    * Specifies the width of the visual presentation
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The parsed width
    */
   width(value) {
@@ -84,9 +84,9 @@ export const parsers = {
   /**
    * Specifies the height of the visual presentation
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The parsed height
    */
   height(value) {
@@ -96,9 +96,9 @@ export const parsers = {
   /**
    * Specifies the bitrate of the representation
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The parsed bandwidth
    */
   bandwidth(value) {
@@ -108,9 +108,9 @@ export const parsers = {
   /**
    * Specifies the number of the first Media Segment in this Representation in the Period
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The parsed number
    */
   startNumber(value) {
@@ -120,9 +120,9 @@ export const parsers = {
   /**
    * Specifies the timescale in units per seconds
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The aprsed timescale
    */
   timescale(value) {
@@ -135,9 +135,10 @@ export const parsers = {
    *       specifies the duration of the Period. This attribute is currently not
    *       supported by the rest of the parser, however we still check for it to prevent
    *       errors.
-   * @param {String} value
+   *
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The parsed duration
    */
   duration(value) {
@@ -153,9 +154,9 @@ export const parsers = {
   /**
    * Specifies the Segment duration, in units of the value of the @timescale.
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The parsed duration
    */
   d(value) {
@@ -166,9 +167,9 @@ export const parsers = {
    * Specifies the MPD start time, in @timescale units, the first Segment in the series
    * starts relative to the beginning of the Period
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The parsed time
    */
   t(value) {
@@ -179,9 +180,9 @@ export const parsers = {
    * Specifies the repeat count of the number of following contiguous Segments with the
    * same duration expressed by the value of @d
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {Number}
+   * @return {number}
    *         The parsed number
    */
   r(value) {
@@ -192,9 +193,9 @@ export const parsers = {
    * Default parser for all other attributes. Acts as a no-op and just returns the value
    * as a string
    *
-   * @param {String} value
+   * @param {string} value
    *        value of attribute as a string
-   * @return {String}
+   * @return {string}
    *         Unparsed value
    */
   DEFAULT(value) {

--- a/src/parseUTCTimingScheme.js
+++ b/src/parseUTCTimingScheme.js
@@ -5,7 +5,7 @@ import errors from './errors';
 /**
  * Parses the manifest for a UTCTiming node, returning the nodes attributes if found
  *
- * @param {String} mpd
+ * @param {string} mpd
  *        XML string of the MPD manifest
  * @return {Object|null}
  *         Attributes of UTCTiming node specified in the manifest. Null if none found

--- a/src/segment/durationTimeParser.js
+++ b/src/segment/durationTimeParser.js
@@ -11,13 +11,12 @@ export const segmentRange = {
     const {
       duration,
       timescale = 1,
-      sourceDuration,
-      startNumber = 1
+      sourceDuration
     } = attributes;
 
     return {
-      start: startNumber,
-      end: startNumber + Math.ceil(sourceDuration / (duration / timescale))
+      start: 0,
+      end: Math.ceil(sourceDuration / (duration / timescale))
     };
   },
   /**
@@ -31,7 +30,6 @@ export const segmentRange = {
       timescale = 1,
       duration,
       start = 0,
-      startNumber = 1,
       minimumUpdatePeriod = 0,
       timeShiftBufferDepth = Infinity
     } = attributes;
@@ -45,8 +43,8 @@ export const segmentRange = {
     const availableEnd = Math.floor((now - periodStartWC) * timescale / duration);
 
     return {
-      start: Math.max(startNumber, availableStart),
-      end: Math.min(startNumber + segmentCount, availableEnd)
+      start: Math.max(0, availableStart),
+      end: Math.min(segmentCount, availableEnd)
     };
   }
 };
@@ -58,11 +56,12 @@ export const toSegments = (attributes) => (number, index) => {
   const {
     duration,
     timescale = 1,
-    periodIndex
+    periodIndex,
+    startNumber = 1
   } = attributes;
 
   return {
-    number,
+    number: startNumber + number,
     duration: duration / timescale,
     timeline: periodIndex,
     time: index * duration

--- a/src/segment/durationTimeParser.js
+++ b/src/segment/durationTimeParser.js
@@ -10,7 +10,7 @@ export const segmentRange = {
    *
    * @param {Object} attributes
    *        Inheritied MPD attributes
-   * @return {{ start: Number, end: Number }}
+   * @return {{ start: number, end: number }}
    *         The start and end numbers for available segments
    */
   static(attributes) {
@@ -31,7 +31,7 @@ export const segmentRange = {
    *
    * @param {Object} attributes
    *        Inheritied MPD attributes
-   * @return {{ start: Number, end: Number }}
+   * @return {{ start: number, end: number }}
    *         The start and end numbers for available segments
    */
   dynamic(attributes) {
@@ -67,9 +67,9 @@ export const segmentRange = {
  *
  * @name toSegmentsCallback
  * @function
- * @param {Number} number
+ * @param {number} number
  *        Number of the segment
- * @param {Number} index
+ * @param {number} index
  *        Index of the number in the range list
  * @return {{ number: Number, duration: Number, timeline: Number, time: Number }}
  *         Object with segment timing and duration info

--- a/src/segment/segmentTemplate.js
+++ b/src/segment/segmentTemplate.js
@@ -122,7 +122,6 @@ export const parseTemplateInfo = (attributes, segmentTimeline) => {
   }
 
   return parseByTimeline(attributes, segmentTimeline);
-
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,6 +16,7 @@ import {
 import {
   parsedManifest as segmentListManifest
 } from './manifests/segmentList.js';
+
 QUnit.module('mpd-parser');
 
 QUnit.test('has VERSION', function(assert) {
@@ -40,7 +41,7 @@ QUnit.test('has parse', function(assert) {
   expected: segmentListManifest
 }].forEach(({ name, input, expected }) => {
   QUnit.test(`${name} test manifest`, function(assert) {
-    const actual = parse(input);
+    const actual = parse(input, { NOW: 10000 });
 
     assert.deepEqual(actual, expected);
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,6 @@ import {
 import {
   parsedManifest as segmentListManifest
 } from './manifests/segmentList.js';
-
 QUnit.module('mpd-parser');
 
 QUnit.test('has VERSION', function(assert) {
@@ -39,7 +38,7 @@ QUnit.test('has parse', function(assert) {
   expected: segmentListManifest
 }].forEach(({ name, input, expected }) => {
   QUnit.test(`${name} test manifest`, function(assert) {
-    const actual = parse(input, { NOW: 10000 });
+    const actual = parse(input);
 
     assert.deepEqual(actual, expected);
   });

--- a/test/segment/segmentTemplate.test.js
+++ b/test/segment/segmentTemplate.test.js
@@ -688,6 +688,456 @@ function(assert) {
 
 });
 
+QUnit.module('segmentTemplate - type ="dynamic"');
+
+QUnit.test('correctly handles duration', function(assert) {
+  const basicAttributes = {
+    baseUrl: 'http://www.example.com/',
+    type: 'dynamic',
+    media: 'n-$Number$.m4s',
+    minimumUpdatePeriod: 0,
+    timescale: 1,
+    NOW: 10000,
+    clientOffset: 0,
+    availabilityStartTime: 0,
+    startNumber: 1,
+    duration: 2,
+    periodIndex: 1
+  };
+
+  assert.deepEqual(
+    segmentsFromTemplate(basicAttributes, []),
+    [{
+      duration: 2,
+      'map': {
+        'resolvedUri': 'http://www.example.com/',
+        'uri': ''
+      },
+      number: 1,
+      resolvedUri: 'http://www.example.com/n-1.m4s',
+      timeline: 1,
+      uri: 'n-1.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 2,
+      resolvedUri: 'http://www.example.com/n-2.m4s',
+      timeline: 1,
+      uri: 'n-2.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 3,
+      resolvedUri: 'http://www.example.com/n-3.m4s',
+      timeline: 1,
+      uri: 'n-3.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 4,
+      resolvedUri: 'http://www.example.com/n-4.m4s',
+      timeline: 1,
+      uri: 'n-4.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 5,
+      resolvedUri: 'http://www.example.com/n-5.m4s',
+      timeline: 1,
+      uri: 'n-5.m4s'
+    }],
+    'segments correctly with basic settings');
+
+  assert.deepEqual(
+    segmentsFromTemplate(Object.assign({}, basicAttributes, { startNumber: 10 }), []),
+    [{
+      duration: 2,
+      'map': {
+        'resolvedUri': 'http://www.example.com/',
+        'uri': ''
+      },
+      number: 10,
+      resolvedUri: 'http://www.example.com/n-10.m4s',
+      timeline: 1,
+      uri: 'n-10.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 11,
+      resolvedUri: 'http://www.example.com/n-11.m4s',
+      timeline: 1,
+      uri: 'n-11.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 12,
+      resolvedUri: 'http://www.example.com/n-12.m4s',
+      timeline: 1,
+      uri: 'n-12.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 13,
+      resolvedUri: 'http://www.example.com/n-13.m4s',
+      timeline: 1,
+      uri: 'n-13.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 14,
+      resolvedUri: 'http://www.example.com/n-14.m4s',
+      timeline: 1,
+      uri: 'n-14.m4s'
+    }],
+    'segments adjusted correctly based on @startNumber');
+
+
+  assert.deepEqual(
+    segmentsFromTemplate(Object.assign({}, basicAttributes,
+      { availabilityStartTime: 4 }), []),
+    [{
+      duration: 2,
+      'map': {
+        'resolvedUri': 'http://www.example.com/',
+        'uri': ''
+      },
+      number: 1,
+      resolvedUri: 'http://www.example.com/n-1.m4s',
+      timeline: 1,
+      uri: 'n-1.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 2,
+      resolvedUri: 'http://www.example.com/n-2.m4s',
+      timeline: 1,
+      uri: 'n-2.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 3,
+      resolvedUri: 'http://www.example.com/n-3.m4s',
+      timeline: 1,
+      uri: 'n-3.m4s'
+    }],
+    'segments correct with @availabilityStartTime set'
+  );
+
+  assert.deepEqual(
+    segmentsFromTemplate(Object.assign({}, basicAttributes,
+      { availabilityStartTime: 2, start: 4 }), []),
+    [{
+      duration: 2,
+      'map': {
+        'resolvedUri': 'http://www.example.com/',
+        'uri': ''
+      },
+      number: 1,
+      resolvedUri: 'http://www.example.com/n-1.m4s',
+      timeline: 1,
+      uri: 'n-1.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 2,
+      resolvedUri: 'http://www.example.com/n-2.m4s',
+      timeline: 1,
+      uri: 'n-2.m4s'
+    }],
+   'segments correct with @availabilityStartTime and @start set');
+
+
+  assert.deepEqual(
+    segmentsFromTemplate(Object.assign({}, basicAttributes,
+      { timeShiftBufferDepth: 4 }, [])),
+    [{
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 4,
+      resolvedUri: 'http://www.example.com/n-4.m4s',
+      timeline: 1,
+      uri: 'n-4.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 5,
+      resolvedUri: 'http://www.example.com/n-5.m4s',
+      timeline: 1,
+      uri: 'n-5.m4s'
+    }],
+   'segments correct with @timeShiftBufferDepth set');
+
+  assert.deepEqual(
+    segmentsFromTemplate(Object.assign({}, basicAttributes,
+      { clientOffset: -2000 }, [])),
+    [{
+      duration: 2,
+      'map': {
+        'resolvedUri': 'http://www.example.com/',
+        'uri': ''
+      },
+      number: 1,
+      resolvedUri: 'http://www.example.com/n-1.m4s',
+      timeline: 1,
+      uri: 'n-1.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 2,
+      resolvedUri: 'http://www.example.com/n-2.m4s',
+      timeline: 1,
+      uri: 'n-2.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 3,
+      resolvedUri: 'http://www.example.com/n-3.m4s',
+      timeline: 1,
+      uri: 'n-3.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 4,
+      resolvedUri: 'http://www.example.com/n-4.m4s',
+      timeline: 1,
+      uri: 'n-4.m4s'
+    }],
+    'segments correct with given clientOffset');
+});
+
+QUnit.test('correctly handles duration with segmentTimeline', function(assert) {
+  const basicAttributes = {
+    baseUrl: 'http://www.example.com/',
+    type: 'dynamic',
+    media: 'n-$Number$.m4s',
+    minimumUpdatePeriod: 2,
+    timescale: 1,
+    NOW: 8000,
+    clientOffset: 0,
+    availabilityStartTime: 0,
+    startNumber: 1,
+    periodIndex: 1
+  };
+
+  const segmentTimeline = [
+    {
+      t: 0,
+      d: 2,
+      r: 1
+    },
+    {
+      d: 2,
+      r: -1
+    }
+  ];
+
+  assert.deepEqual(
+    segmentsFromTemplate(basicAttributes, segmentTimeline),
+      [{
+        duration: 2,
+        'map': {
+          'resolvedUri': 'http://www.example.com/',
+          'uri': ''
+        },
+        number: 1,
+        resolvedUri: 'http://www.example.com/n-1.m4s',
+        timeline: 1,
+        uri: 'n-1.m4s'
+      }, {
+        duration: 2,
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
+        },
+        number: 2,
+        resolvedUri: 'http://www.example.com/n-2.m4s',
+        timeline: 1,
+        uri: 'n-2.m4s'
+      }, {
+        duration: 2,
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
+        },
+        number: 3,
+        resolvedUri: 'http://www.example.com/n-3.m4s',
+        timeline: 1,
+        uri: 'n-3.m4s'
+      }, {
+        duration: 2,
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
+        },
+        number: 4,
+        resolvedUri: 'http://www.example.com/n-4.m4s',
+        timeline: 1,
+        uri: 'n-4.m4s'
+      }, {
+        duration: 2,
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
+        },
+        number: 5,
+        resolvedUri: 'http://www.example.com/n-5.m4s',
+        timeline: 1,
+        uri: 'n-5.m4s'
+      }],
+      'segments should fill until current time when r = -1 and @minimumUpdatePeriod > 0');
+
+  assert.deepEqual(
+    segmentsFromTemplate(
+      Object.assign({}, basicAttributes, {clientOffset: -2000}), segmentTimeline),
+      [{
+        duration: 2,
+        'map': {
+          'resolvedUri': 'http://www.example.com/',
+          'uri': ''
+        },
+        number: 1,
+        resolvedUri: 'http://www.example.com/n-1.m4s',
+        timeline: 1,
+        uri: 'n-1.m4s'
+      }, {
+        duration: 2,
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
+        },
+        number: 2,
+        resolvedUri: 'http://www.example.com/n-2.m4s',
+        timeline: 1,
+        uri: 'n-2.m4s'
+      }, {
+        duration: 2,
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
+        },
+        number: 3,
+        resolvedUri: 'http://www.example.com/n-3.m4s',
+        timeline: 1,
+        uri: 'n-3.m4s'
+      }, {
+        duration: 2,
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
+        },
+        number: 4,
+        resolvedUri: 'http://www.example.com/n-4.m4s',
+        timeline: 1,
+        uri: 'n-4.m4s'
+      }],
+      'segments should fill correctly when taking client offset into account');
+
+    const segmentTimelineShifted = [
+      {
+        t: 2,
+        d: 2,
+        r: 1
+      },
+      {
+        d: 2,
+        r: -1
+      }
+    ];
+
+  assert.deepEqual(
+    segmentsFromTemplate(basicAttributes, segmentTimelineShifted),
+    [{
+      duration: 2,
+      'map': {
+        'resolvedUri': 'http://www.example.com/',
+        'uri': ''
+      },
+      number: 1,
+      resolvedUri: 'http://www.example.com/n-1.m4s',
+      timeline: 1,
+      uri: 'n-1.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 2,
+      resolvedUri: 'http://www.example.com/n-2.m4s',
+      timeline: 1,
+      uri: 'n-2.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 3,
+      resolvedUri: 'http://www.example.com/n-3.m4s',
+      timeline: 1,
+      uri: 'n-3.m4s'
+    }, {
+      duration: 2,
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
+      },
+      number: 4,
+      resolvedUri: 'http://www.example.com/n-4.m4s',
+      timeline: 1,
+      uri: 'n-4.m4s'
+    }],
+    'segments take into account different time value for first segment');
+});
+
 QUnit.module('segmentTemplate - segmentsFromTemplate');
 
 QUnit.test('constructs simple segment list and resolves uris', function(assert) {

--- a/test/segment/segmentTemplate.test.js
+++ b/test/segment/segmentTemplate.test.js
@@ -709,9 +709,9 @@ QUnit.test('correctly handles duration', function(assert) {
     segmentsFromTemplate(basicAttributes, []),
     [{
       duration: 2,
-      'map': {
-        'resolvedUri': 'http://www.example.com/',
-        'uri': ''
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
       },
       number: 1,
       resolvedUri: 'http://www.example.com/n-1.m4s',
@@ -764,9 +764,9 @@ QUnit.test('correctly handles duration', function(assert) {
     segmentsFromTemplate(Object.assign({}, basicAttributes, { startNumber: 10 }), []),
     [{
       duration: 2,
-      'map': {
-        'resolvedUri': 'http://www.example.com/',
-        'uri': ''
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
       },
       number: 10,
       resolvedUri: 'http://www.example.com/n-10.m4s',
@@ -815,15 +815,14 @@ QUnit.test('correctly handles duration', function(assert) {
     }],
     'segments adjusted correctly based on @startNumber');
 
-
   assert.deepEqual(
     segmentsFromTemplate(Object.assign({}, basicAttributes,
       { availabilityStartTime: 4 }), []),
     [{
       duration: 2,
-      'map': {
-        'resolvedUri': 'http://www.example.com/',
-        'uri': ''
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
       },
       number: 1,
       resolvedUri: 'http://www.example.com/n-1.m4s',
@@ -858,9 +857,9 @@ QUnit.test('correctly handles duration', function(assert) {
       { availabilityStartTime: 2, start: 4 }), []),
     [{
       duration: 2,
-      'map': {
-        'resolvedUri': 'http://www.example.com/',
-        'uri': ''
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
       },
       number: 1,
       resolvedUri: 'http://www.example.com/n-1.m4s',
@@ -878,7 +877,6 @@ QUnit.test('correctly handles duration', function(assert) {
       uri: 'n-2.m4s'
     }],
    'segments correct with @availabilityStartTime and @start set');
-
 
   assert.deepEqual(
     segmentsFromTemplate(Object.assign({}, basicAttributes,
@@ -911,9 +909,9 @@ QUnit.test('correctly handles duration', function(assert) {
       { clientOffset: -2000 }, [])),
     [{
       duration: 2,
-      'map': {
-        'resolvedUri': 'http://www.example.com/',
-        'uri': ''
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
       },
       number: 1,
       resolvedUri: 'http://www.example.com/n-1.m4s',
@@ -983,9 +981,9 @@ QUnit.test('correctly handles duration with segmentTimeline', function(assert) {
     segmentsFromTemplate(basicAttributes, segmentTimeline),
       [{
         duration: 2,
-        'map': {
-          'resolvedUri': 'http://www.example.com/',
-          'uri': ''
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
         },
         number: 1,
         resolvedUri: 'http://www.example.com/n-1.m4s',
@@ -1039,9 +1037,9 @@ QUnit.test('correctly handles duration with segmentTimeline', function(assert) {
       Object.assign({}, basicAttributes, {clientOffset: -2000}), segmentTimeline),
       [{
         duration: 2,
-        'map': {
-          'resolvedUri': 'http://www.example.com/',
-          'uri': ''
+        map: {
+          resolvedUri: 'http://www.example.com/',
+          uri: ''
         },
         number: 1,
         resolvedUri: 'http://www.example.com/n-1.m4s',
@@ -1080,25 +1078,25 @@ QUnit.test('correctly handles duration with segmentTimeline', function(assert) {
       }],
       'segments should fill correctly when taking client offset into account');
 
-    const segmentTimelineShifted = [
-      {
-        t: 2,
-        d: 2,
-        r: 1
-      },
-      {
-        d: 2,
-        r: -1
-      }
-    ];
+  const segmentTimelineShifted = [
+    {
+      t: 2,
+      d: 2,
+      r: 1
+    },
+    {
+      d: 2,
+      r: -1
+    }
+  ];
 
   assert.deepEqual(
     segmentsFromTemplate(basicAttributes, segmentTimelineShifted),
     [{
       duration: 2,
-      'map': {
-        'resolvedUri': 'http://www.example.com/',
-        'uri': ''
+      map: {
+        resolvedUri: 'http://www.example.com/',
+        uri: ''
       },
       number: 1,
       resolvedUri: 'http://www.example.com/n-1.m4s',


### PR DESCRIPTION
This PR adds some logic for the scenario described in the DASH spec for r=-1, where the `@minimumUpdatePeriod` > 0 (basically it should go until the end of the period/calculate up until the current now).  

This PR also resolves a bug that was found while writing tests in the case where `@duration` is set.  Logic for where the `@startNumber` is used is shifted slightly.

Also added a series of tests to cover live scenarios.

There are also some minor comment changes here, as eslint was spitting out warnings and it seemed like a good idea to clean that up.

A bulk of the actual code changes here are in `src/segment/timelineTimeParser.js`, `src/segment/durationTimeParser.js` and `test/segmentTemplate.test.js`.